### PR TITLE
Fixes broken items and optional relationships

### DIFF
--- a/src/Helper/ResourceBag.php
+++ b/src/Helper/ResourceBag.php
@@ -181,9 +181,11 @@ class ResourceBag {
             $methodName = $this->camelizeString('include', $resource);
 
             $item = $this->transformer->{$methodName}($this->data);
-            $data = $item->identifiers($this->serializer);
+            if ($item) {
+                $data = $item->identifiers($this->serializer);
 
-            $resources[!is_numeric($key) ? $key : $resource] = $this->serializer->sideload($data, $item->getTransformer()->getTypeKey());
+                $resources[!is_numeric($key) ? $key : $resource] = $this->serializer->sideload($data, $item->getTransformer()->getTypeKey());
+            }
         }
 
         return $resources;
@@ -203,9 +205,9 @@ class ResourceBag {
 
           $methodName = $this->camelizeString('include', $resource);
 
-          $transformer = $this->transformer->{$methodName}($this->data);
-          
-          if ($transformer) {
+          $item = $this->transformer->{$methodName}($this->data);
+
+          if ($item) {
             $data = $item->create($this->serializer);
 
             if ($group) {


### PR DESCRIPTION
This PR fixes two issues.

* On line 208, `$transformer` should have been named `$item` and this was causing an undefined variable issue
* In `fetchSideloads`, sideloaded relationships should be optional. If no item is returned then the relationship should not be included in the data.

Thank you for the awesome work with making a more compliant and flexible JSON API adapter.

I hope these contributions help get things moving even further and pull out some edgecases