### PR TITLE
Refactor transformers and clean up tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ Manuel
 
 The easy to use PHP Serializer. Because translation shouldn't be a chore.
 
-This project was heavily inspired by PHP League's Fractal project.
-
 #### How to use
 
 To serialize an object you first need to create a transformer. Transformers must implement the transform method and return an array. Transformers can accept any type of data or object that requires serialisation.
@@ -25,16 +23,6 @@ class MyTransformer extends TransformerAbstract {
     protected $type = 'customer';
 
     /**
-     * @var array
-     */
-    protected $relationships = [ 'organisation' ];
-
-    /**
-     * @var array
-     */
-    protected $linkedResources = [ 'tasks' ];
-
-    /**
      * Transform object properties.
      *
      * @param TheObject $myObject
@@ -51,25 +39,15 @@ class MyTransformer extends TransformerAbstract {
     }
 
     /**
-     * Create link to external resource.
+     * Define other resources to be included in transformation.
      *
      * @param TheObject $myObject
-     * @return string
      */
-    public function linkedTasks(TheObject $myObject)
+    public function defineResources(TheObject $myObject)
     {
-        return "/customer/{$myObject->id}/tasks";
-    }
+        $this->addLink("/customer/{$myObject->id}/tasks");
 
-    /**
-     * Create a simple resource.
-     *
-     * @param TheObject $myObject
-     * @return integer
-     */
-    public function relationshipOrganisation(TheObject $myObject)
-    {
-        return (int) $myObject->organisation_id;
+        $this->addRelationship('organisation', $myObject->organisation_id);
     }
 
 }
@@ -141,30 +119,17 @@ Much like simple relationships, embedded resources can be used to nest another r
 ```php
 <?php
 
-  /**
-   * @var inheritdoc
-   */
-  protected $embeddedResources = [ 'test_item', 'test_collection' ];
+    /**
+     * Define other resources to be included in transformation.
+     *
+     * @param TheObject $myObject
+     */
+    public function defineResources(TheObject $myObject)
+    {
+        $this->addResource('test_item', new Item($data->item, new Transformer));
 
-  /**
-   *
-   * @param MyObject $data
-   * @return Item
-   */
-  public function embeddedTestItem($data)
-  {
-    return new Item($data->item), new Transformer);
-  }
-
-  /**
-   *
-   * @param MyObject $data
-   * @return Collection
-   */
-  public function embeddedTestCollection($data)
-  {
-    return new Collection($data->items, new Transformer);
-  }
+        $this->addResource('test_collection', new Collection($data->items, new Transformer));
+    }
 
 ```
 
@@ -175,30 +140,17 @@ This type of resource will be included along side the main resource and referenc
 ```php
 <?php
 
-  /**
-   * @var inheritdoc
-   */
-  protected $includedResources = [ 'test_item', 'test_collection' ];
+    /**
+     * Define other resources to be included in transformation.
+     *
+     * @param TheObject $myObject
+     */
+    public function defineResources(TheObject $myObject)
+    {
+        $this->addResource('test_item', new Item($data->item, new Transformer), true);
 
-  /**
-   *
-   * @param MyObject $data
-   * @return Item
-   */
-  public function includeTestItem($data)
-  {
-    return new Item($data->item, new Transformer);
-  }
-
-  /**
-   *
-   * @param MyObject $data
-   * @return Collection
-   */
-  public function includeTestCollection($data)
-  {
-    return new Collection($data->items, new Transformer);
-  }
+        $this->addResource('test_collection', new Collection($data->items, new Transformer), true);
+    }
 
 ```
 #### Serializers

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ class MyTransformer extends TransformerAbstract {
      *
      * @param TheObject $myObject
      */
-    public function defineResources(TheObject $myObject)
+    public function resources(TheObject $myObject)
     {
         $this->addLink("/customer/{$myObject->id}/tasks");
 
@@ -117,20 +117,17 @@ Much like simple relationships, this type of resource can be used to create a li
 Much like simple relationships, embedded resources can be used to nest another resource within the resource tree. Embedded resources can be either a ```Collection``` or ```Item``` and the serializer will attempt to serialize all relationships underneath.
 
 ```php
-<?php
-
     /**
      * Define other resources to be included in transformation.
      *
      * @param TheObject $myObject
      */
-    public function defineResources(TheObject $myObject)
+    public function resources(TheObject $myObject)
     {
         $this->addResource('test_item', new Item($data->item, new Transformer));
 
         $this->addResource('test_collection', new Collection($data->items, new Transformer));
     }
-
 ```
 
 **Sideloaded Resources**
@@ -138,20 +135,17 @@ Much like simple relationships, embedded resources can be used to nest another r
 This type of resource will be included along side the main resource and references to the resource identifiers can be loaded as part of the relationship serialization.
 
 ```php
-<?php
-
     /**
      * Define other resources to be included in transformation.
      *
      * @param TheObject $myObject
      */
-    public function defineResources(TheObject $myObject)
+    public function resources(TheObject $myObject)
     {
         $this->addResource('test_item', new Item($data->item, new Transformer), true);
 
         $this->addResource('test_collection', new Collection($data->items, new Transformer), true);
     }
-
 ```
 #### Serializers
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "bobbysciacchitano/manuel",
     "description": "A simple object serializer for PHP which supports flexible document structures.",
-    "keywords": ["JsonAPI", "transformer", "serializer", "formatter", "json", "encoder"],
+    "keywords": ["JsonAPI", "transformer", "serializer", "formatter", "json", "encoder", "data mapper", "mapper"],
     "homepage": "https://github.com/bobbysciacchitano/manuel",
     "license": "MIT",
     "type": "library",

--- a/src/Helper/ResourceBag.php
+++ b/src/Helper/ResourceBag.php
@@ -1,5 +1,6 @@
 <?php namespace Manuel\Helper;
 
+use Manuel\Resource\ResourceAbstract;
 use Manuel\Serializer\SerializerAbstract;
 use Manuel\Transformer\TransformerAbstract;
 
@@ -36,8 +37,10 @@ class ResourceBag {
     public function __construct($data, TransformerAbstract $transformer, SerializerAbstract $serializer)
     {
         $this->data = $data;
-        $this->transformer = $transformer;
         $this->serializer  = $serializer;
+
+        $this->transformer = $transformer;
+        $this->transformer->defineResources($data);
     }
 
     /**
@@ -45,7 +48,7 @@ class ResourceBag {
      *
      * @return boolean
      */
-    public function containsRelationships() {
+    public function containsResources() {
         if (
           $this->transformer->getRelationships() ||
           $this->transformer->getLinkedResources() ||
@@ -78,10 +81,7 @@ class ResourceBag {
         $resources = array();
 
         foreach ($this->transformer->getRelationships() as $key => $resource) {
-
-            $methodName = $this->camelizeString('relationship', !is_numeric($key) ? $key : $resource);
-
-            $resources[!is_numeric($key) ? $key : $resource] = $this->serializer->simple($this->transformer->{$methodName}($this->data), $resource);
+            $resources[$key] = $this->serializer->simple($resource, $key);
         }
 
         return $resources;
@@ -109,10 +109,7 @@ class ResourceBag {
         $resources = array();
 
         foreach ($this->transformer->getLinkedResources() as $key => $resource) {
-
-            $methodName = $this->camelizeString('linked', $resource);
-
-            $resources[!is_numeric($key) ? $key : $resource] = $this->serializer->link($this->transformer->{$methodName}($this->data), $resource);
+            $resources[$key] = $this->serializer->link($resource, $key);
         }
 
         return $resources;
@@ -141,15 +138,13 @@ class ResourceBag {
 
         foreach ($this->transformer->getEmbeddedResources() as $key => $resource) {
 
-            $methodName = $this->camelizeString('embedded', $resource);
-
-            $transformer = $this->transformer->{$methodName}($this->data);
-
-            if ($transformer) {
-                $data = $transformer->create($this->serializer);
-
-                $resources[!is_numeric($key) ? $key : $resource] = $this->serializer->embedded($data, $resource);
+            if ($resource instanceof ResourceAbstract) {
+                $data = $resource->create($this->serializer);
+            } else {
+                $data = $resource;
             }
+
+            $resources[$key] = $this->serializer->embedded($data, $key);
         }
 
         return $resources;
@@ -177,14 +172,10 @@ class ResourceBag {
         $resources = array();
 
         foreach ($this->transformer->getIncludedResources() as $key => $resource) {
+            if ($resource instanceof ResourceAbstract) {
+                $data = $resource->identifiers($this->serializer);
 
-            $methodName = $this->camelizeString('include', $resource);
-
-            $item = $this->transformer->{$methodName}($this->data);
-            if ($item) {
-                $data = $item->identifiers($this->serializer);
-
-                $resources[!is_numeric($key) ? $key : $resource] = $this->serializer->sideload($data, $item->getTransformer()->getTypeKey());
+                $resources[$key] = $this->serializer->sideload($data, $resource->getTransformer()->getTypeKey());
             }
         }
 
@@ -202,40 +193,25 @@ class ResourceBag {
       $resources = array();
 
       foreach ($this->transformer->getIncludedResources() as $key => $resource) {
+          if ($resource instanceof ResourceAbstract) {
+              $data = $resource->create($this->serializer);
 
-          $methodName = $this->camelizeString('include', $resource);
+              if ($group) {
+                  $resources[!is_numeric($key) ? $key : $resource] = $data;
+              } else {
+                  if($resource->returnsCollection()) {
+                      $resources = array_merge($resources, $data);
+                  } else {
+                      $resources[] = $data;
+                  }
+              }
+          } else {
 
-          $item = $this->transformer->{$methodName}($this->data);
-
-          if ($item) {
-            $data = $item->create($this->serializer);
-
-            if ($group) {
-                $resources[!is_numeric($key) ? $key : $resource] = $data;
-            } else {
-                if($item->returnsCollection()) {
-                    $resources = array_merge($resources, $data);
-                } else {
-                    $resources[] = $data;
-                }
-            }
           }
+
       }
 
       return $resources;
-    }
-
-    /**
-     * Return a camelized string reference to a method that should
-     * be loaded from the item.
-     *
-     * @param string $key
-     * @param string $resource
-     * @return string
-     */
-    private function camelizeString($type, $resource)
-    {
-        return $type . implode('', array_map('ucfirst', array_map('strtolower', preg_split('/[\s_-]/', $resource))));
     }
 
 }

--- a/src/Helper/ResourceBag.php
+++ b/src/Helper/ResourceBag.php
@@ -40,7 +40,10 @@ class ResourceBag {
         $this->serializer  = $serializer;
 
         $this->transformer = $transformer;
-        $this->transformer->defineResources($data);
+
+        if (method_exists($transformer, 'resources')) {
+            $this->transformer->resources($data);
+        }
     }
 
     /**

--- a/src/Serializer/JsonAPISerializer.php
+++ b/src/Serializer/JsonAPISerializer.php
@@ -18,7 +18,7 @@ class JsonAPISerializer extends SerializerAbstract {
 
         unset($resource['attributes']['id']);
 
-        foreach ($transformer->getRelationships() as $relationship) {
+        foreach (array_keys($transformer->getRelationships()) as $relationship) {
             unset($resource['attributes'][$relationship]);
         }
 
@@ -72,7 +72,7 @@ class JsonAPISerializer extends SerializerAbstract {
      */
     public function relationships(ResourceBag $resourceBag)
     {
-        if (!$resourceBag->containsRelationships()) {
+        if (!$resourceBag->containsResources()) {
             return array();
         }
 

--- a/src/Serializer/SerializerAbstract.php
+++ b/src/Serializer/SerializerAbstract.php
@@ -95,7 +95,7 @@ class SerializerAbstract {
      */
     public function relationships(ResourceBag $resourceBag)
     {
-        if (!$resourceBag->containsRelationships()) {
+        if (!$resourceBag->containsResources()) {
             return array();
         }
 

--- a/src/Transformer/TransformerAbstract.php
+++ b/src/Transformer/TransformerAbstract.php
@@ -93,16 +93,6 @@ abstract class TransformerAbstract {
     }
 
     /**
-     * Define resources to be included in serialization.
-     *
-     * @param $data
-     */
-    public function defineResources($data)
-    {
-
-    }
-
-    /**
      * Add a simple identifier or relationship resource.
      *
      * @param string $name

--- a/src/Transformer/TransformerAbstract.php
+++ b/src/Transformer/TransformerAbstract.php
@@ -53,7 +53,7 @@ abstract class TransformerAbstract {
     }
 
     /**
-     * Return an array of simple relationship names for thie resource.
+     * Return an array of simple relationship names for this resource.
      *
      * @return array
      */
@@ -90,6 +90,61 @@ abstract class TransformerAbstract {
     public function getIncludedResources()
     {
         return $this->includedResources;
+    }
+
+    /**
+     * Define resources to be included in serialization.
+     *
+     * @param $data
+     */
+    public function defineResources($data)
+    {
+
+    }
+
+    /**
+     * Add a simple identifier or relationship resource.
+     *
+     * @param string $name
+     * @param mixed $data
+     */
+    public function addRelationship($name, $data)
+    {
+        $this->relationships[$name] = $data;
+    }
+
+    /**
+     * Add link resource to serialization structure.
+     *
+     * @param string $name
+     * @param string $link
+     * @return $this
+     */
+    public function addLink($name, $link)
+    {
+        $this->linkedResources[$name] = $link;
+
+        return $this;
+    }
+
+    /**
+     * Add resource to serialization structure and define whether resource should be
+     * treated as a sideload.
+     *
+     * @param string $name
+     * @param mixed $resource
+     * @param bool $sideload
+     * @return $this
+     */
+    public function addResource($name, $resource, $sideload = false)
+    {
+        if ($sideload) {
+            $this->includedResources[$name] = $resource;
+        } else {
+            $this->embeddedResources[$name] = $resource;
+        }
+
+        return $this;
     }
 
 }

--- a/tests/helpers/ResourceBagTest.php
+++ b/tests/helpers/ResourceBagTest.php
@@ -19,7 +19,7 @@ class ResourceBagTest extends PHPUnit_Framework_TestCase {
 
   public function testCanLoadResources()
   {
-    $this->assertTrue($this->resourceBag->containsRelationships());
+    $this->assertTrue($this->resourceBag->containsResources());
   }
 
   public function testContainsSimple()

--- a/tests/mocks/DummyTransformer.php
+++ b/tests/mocks/DummyTransformer.php
@@ -30,7 +30,7 @@ class DummyTransformer extends TransformerAbstract {
      *
      * @param $data
      */
-    public function defineResources($data)
+    public function resources($data)
     {
         // Test Simple
         $this->addRelationship('simple_item', 2);

--- a/tests/mocks/DummyTransformer.php
+++ b/tests/mocks/DummyTransformer.php
@@ -6,122 +6,61 @@ use Manuel\Resource\Collection;
 
 class DummyTransformer extends TransformerAbstract {
 
-  /**
-   * @inheritdoc
-   */
-  protected $type = 'test';
+    /**
+     * @inheritdoc
+     */
+    protected $type = 'test';
 
-  /**
-   * @inheritdoc
-   */
-  protected $relationships = [ 'simple_item', 'simple_collection', 'relation_returns_null' ];
-
-  /**
-   * @inheritdoc
-   */
-  protected $linkedResources = [ 'simple_linked' ];
-
-  /**
-   * @inheritdoc
-   */
-  protected $embeddedResources = [ 'test_item', 'test_collection' ];
-
-  /**
-   * @inheritdoc
-   */
-  protected $includedResources = [ 'sideload_item', 'sideload_collection' ];
-
-  /**
-   *
-   *
-   * @param array $data
-   * @return array
-   */
-  public function transform($data)
-  {
-    return array(
-      'id'   => (int) $data['id'],
-      'test' => 'data_' . $data['id']
-    );
-  }
-
-  /**
-   *
-   * @param array $data
-   * @return integer
-   */
-  public function relationshipSimpleItem($data)
-  {
-    return 2;
-  }
-
-  /**
-   *
-   * @param array $data
-   * @return array
-   */
-  public function relationshipSimpleCollection($data)
-  {
-    return [3, 4];
-  }
-
-  /**
-   *
-   * @param array $data
-   * @return string
-   */
-  public function linkedSimpleLinked($data)
-  {
-    return '/customer/1/testing';
-  }
-
-  /**
-   *
-   * @param array $data
-   * @return Item
-   */
-  public function embeddedTestItem($data)
-  {
-    return new Item(array('id' => 5), new DummyEmbeddedTransformer);
-  }
-
-  /**
-   *
-   * @param array $data
-   * @return Collection
-   */
-  public function embeddedTestCollection($data)
-  {
-    $items = array(array('id' => 6), array('id' => 7));
-
-    return new Collection($items, new DummyEmbeddedTransformer);
-  }
-
-  /**
-   *
-   * @param array $data
-   * @return Item
-   */
-  public function includeSideloadItem($data)
-  {
-    return new Item(array('id' => 8), new DummyEmbeddedTransformer);
-  }
-
-  /**
-   *
-   * @param array $data
-   * @return Collection
-   */
-  public function includeSideloadCollection($data)
-  {
-    $items = array(array('id' => 9), array('id' => 10));
-
-    return new Collection($items, new DummyEmbeddedTransformer);
-  }
-
-    public function relationshipRelationReturnsNull($data)
+    /**
+     *
+     *
+     * @param array $data
+     * @return array
+     */
+    public function transform($data)
     {
-        return null;
+      return array(
+        'id'   => (int) $data['id'],
+        'test' => 'data_' . $data['id']
+      );
+    }
+
+    /**
+     *
+     *
+     * @param $data
+     */
+    public function defineResources($data)
+    {
+        // Test Simple
+        $this->addRelationship('simple_item', 2);
+
+        $this->addRelationship('simple_collection', [3, 4]);
+
+        $this->addRelationship('relation_returns_null', null);
+
+        // Test Link
+        $this->addLink('simple_linked', '/customer/1/testing');
+
+
+        // Test Embedded
+        $test = array('id' => 5);
+
+        $this->addResource('test_item', new Item($test, new DummyEmbeddedTransformer));
+
+        $test = array(array('id' => 6), array('id' => 7));
+
+        $this->addResource('test_collection', new Collection($test, new DummyEmbeddedTransformer));
+
+
+        // Test Included
+        $test = array('id' => 8);
+
+        $this->addResource('sideload_item', new Item($test, new DummyEmbeddedTransformer), true);
+
+        $test = array(array('id' => 9), array('id' => 10));
+
+        $this->addResource('sideload_collection', new Collection($test, new DummyEmbeddedTransformer), true);
     }
 
 }

--- a/tests/transformer/TransformerTest.php
+++ b/tests/transformer/TransformerTest.php
@@ -5,39 +5,52 @@ require_once __DIR__ . '/../mocks/DummyEmbeddedTransformer.php';
 
 class TransformerTest extends PHPUnit_Framework_TestCase {
 
-  public function testPrimaryKey()
-  {
-    $transformer = new DummyTransformer;
+    public function setUp()
+    {
+        $this->transformer = new DummyTransformer();
+        $this->transformer->defineResources(array());
+    }
 
-    $this->assertEquals('id', $transformer->getPrimaryKeyName());
-  }
+    public function testPrimaryKey()
+    {
+        $transformer = new DummyTransformer;
 
-  public function testTypeKey()
-  {
-    $transformer = new DummyTransformer;
+        $this->assertEquals('id', $transformer->getPrimaryKeyName());
+    }
 
-    $this->assertEquals('test', $transformer->getTypeKey());
-  }
+    public function testTypeKey()
+    {
+        $transformer = new DummyTransformer;
 
-  public function testRelationships()
-  {
-    $transformer = new DummyTransformer;
+        $this->assertEquals('test', $transformer->getTypeKey());
+    }
 
-    $this->assertEquals(array('simple_item', 'simple_collection', 'relation_returns_null'), $transformer->getRelationships());
-  }
+    public function testRelationships()
+    {
+        $actual = array_keys($this->transformer->getRelationships());
 
-  public function testLinkedResources()
-  {
-    $transformer = new DummyTransformer;
+        $this->assertEquals(array('simple_item', 'simple_collection', 'relation_returns_null'), $actual);
+    }
 
-    $this->assertEquals(array('simple_linked'), $transformer->getLinkedResources());
-  }
+    public function testLinkedResources()
+    {
+        $actual = array_keys($this->transformer->getLinkedResources());
 
-  public function testEmbeddedResources()
-  {
-    $transformer = new DummyTransformer;
+        $this->assertEquals(array('simple_linked'), $actual);
+    }
 
-    $this->assertEquals(array('test_item', 'test_collection'), $transformer->getEmbeddedResources());
-  }
+    public function testEmbeddedResources()
+    {
+        $actual = array_keys($this->transformer->getEmbeddedResources());
+
+        $this->assertEquals(array('test_item', 'test_collection'), $actual);
+    }
+
+    public function testSideloadedResources()
+    {
+        $actual = array_keys($this->transformer->getIncludedResources());
+
+        $this->assertEquals(array('sideload_item', 'sideload_collection'), $actual);
+    }
 
 }

--- a/tests/transformer/TransformerTest.php
+++ b/tests/transformer/TransformerTest.php
@@ -8,7 +8,7 @@ class TransformerTest extends PHPUnit_Framework_TestCase {
     public function setUp()
     {
         $this->transformer = new DummyTransformer();
-        $this->transformer->defineResources(array());
+        $this->transformer->resources(array());
     }
 
     public function testPrimaryKey()


### PR DESCRIPTION
This introduces a new API which replaces the existing transformer object. It improves the developer UX for when it comes to composing transformers.

Since this is a backwards incompatible change, it will be released a v2.0.0.