### PR TITLE
Fixed issue when collections would reuse transformer on serialization

### DIFF
--- a/src/Resource/Collection.php
+++ b/src/Resource/Collection.php
@@ -16,9 +16,10 @@ class Collection extends ResourceAbstract {
     {
         $resources = array();
 
-        foreach ($this->data as $data) {
+        $transformerClass = get_class($this->transformer);
 
-            $resource = new Item($data, $this->transformer, $this->resourceKey);
+        foreach ($this->data as $data) {
+            $resource = new Item($data, new $transformerClass, $this->resourceKey);
 
             $resources[] = $resource->create($serializer);
         }
@@ -34,7 +35,6 @@ class Collection extends ResourceAbstract {
         $resources = array();
 
         foreach ($this->data as $data) {
-
             $resource = new Item($data, $this->transformer, $this->resourceKey);
 
             $resources[] = $resource->identifiers();


### PR DESCRIPTION
Create a new instance of the transformer when iterating through a collection. This fixes an issue where in some instances the resources would not be reset.

Needs a better refactor...