### PR TITLE
Do not throw exception on missing typecast items

### DIFF
--- a/src/Resource/Item.php
+++ b/src/Resource/Item.php
@@ -10,6 +10,11 @@ class Item extends ResourceAbstract {
      */
     public function create(SerializerAbstract $serializer)
     {
+        // If data is empty, do nothing.
+        if (!$this->data) {
+            return null;
+        }
+
         // Create a new Resource bag for transforming relationships.
         $resourceBag = new ResourceBag($this->data, $this->transformer, $serializer);
 


### PR DESCRIPTION
Basically resolves a long standing issue where you cannot serialise typecast objects meaning you have to check in the transformer.

From now on if the resource manager receives a null, return null.